### PR TITLE
Intrument tracing for Pub task

### DIFF
--- a/pubtools/_quay/command_executor.py
+++ b/pubtools/_quay/command_executor.py
@@ -15,6 +15,8 @@ import docker
 import paramiko
 from shlex import quote
 
+from .utils.tracing import instrument_func
+
 LOG = logging.getLogger("pubtools.quay")
 
 
@@ -160,6 +162,7 @@ class LocalExecutor(Executor):
         self.params.setdefault("stdout", subprocess.PIPE)
         self.params.setdefault("stdin", subprocess.PIPE)
 
+    @instrument_func()
     def _run_cmd(self, cmd, err_msg=None, tolerate_err=False, stdin=None):
         """
         Run a command locally.

--- a/pubtools/_quay/manifest_claims_handler.py
+++ b/pubtools/_quay/manifest_claims_handler.py
@@ -8,6 +8,8 @@ import proton
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 
+from .utils.tracing import instrument_func
+
 LOG = logging.getLogger("pubtools.quay")
 
 # There are some linting errors since this was copied from rcm-pub
@@ -161,6 +163,7 @@ class ManifestClaimsHandler(MessagingHandler):
         self.ssl_domain.set_trusted_ca_db(settings.ca_cert)
         self.ssl_domain.set_peer_authentication(proton.SSLDomain.ANONYMOUS_PEER)
 
+    @instrument_func()
     def on_start(self, event):  # pragma: no cover
         LOG.debug("Message event loop starting, connecting to brokers...")
         conn = event.container.connect(
@@ -171,6 +174,7 @@ class ManifestClaimsHandler(MessagingHandler):
         # schedule a timer task, if the connection to UMB could be established, raise exception.
         LOG.debug("Message event loop started")
 
+    @instrument_func()
     def on_timer_task(self, event):
         """timer task has three functionalities:
         1. if it couldn't be connected to brokers, then after self.timeout, exception
@@ -228,6 +232,7 @@ class ManifestClaimsHandler(MessagingHandler):
         else:
             LOG.warning("Unexpected on_link_opened event")
 
+    @instrument_func()
     def on_message(self, event):
         """Once receive a message, check if it's expected by checking the awaiting_response,
         if it is, then append it to received and remove it from awaiting_response.
@@ -310,6 +315,7 @@ class ManifestClaimsHandler(MessagingHandler):
             if error_tag in self._PROTON_KNOWN_UNHANDLED_ERRORS:
                 self._endpoint_error(event, endpoint)
 
+    @instrument_func()
     def _send_message(self, count=None):
         if not self.to_send:  # pragma: no cover
             return

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -22,6 +22,7 @@ from .utils.misc import (
 from .quay_client import QuayClient
 from .utils.misc import parse_index_image, pyxis_get_repo_metadata
 from .models import BuildIndexImageParam
+from .utils.tracing import instrument_func
 
 LOG = logging.getLogger("pubtools.quay")
 
@@ -262,6 +263,7 @@ class OperatorPusher:
         return (args, env_vars)
 
     @classmethod
+    @instrument_func()
     def iib_add_bundles(
         cls,
         bundles=None,
@@ -324,6 +326,7 @@ class OperatorPusher:
             return False
 
     @classmethod
+    @instrument_func()
     def iib_remove_operators(
         cls,
         operators=None,

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -13,6 +13,8 @@ import time
 from io import StringIO
 from pubtools.pluggy import pm
 
+from .tracing import instrument_func
+
 LOG = logging.getLogger("pubtools.quay")
 
 INTERNAL_DELIMITER = "----"
@@ -241,6 +243,9 @@ def log_step(step_name):
     event_name = step_name.lower().replace(" ", "-")
 
     def decorate(fn):
+        # Add instrumentation trace for all push steps.
+        fn = instrument_func()(fn)
+
         @functools.wraps(fn)
         def fn_wrapper(*args, **kwargs):
             try:

--- a/pubtools/_quay/utils/tracing.py
+++ b/pubtools/_quay/utils/tracing.py
@@ -1,0 +1,106 @@
+"""Instrument Pub task functions.
+
+Usage:
+    @instrument_func()
+      def func():
+          pass
+
+"""
+import os
+import functools
+import logging
+
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+)
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry import baggage
+
+
+propagator = TraceContextTextMapPropagator()
+log = logging.getLogger(__name__)
+
+
+class TracingWrapper:
+    """Wrapper class that will wrap all methods of calls with the instrument_tracing decorator."""
+
+    __instance = None
+
+    def __new__(cls):
+        """Create a new instance if one does not exist."""
+        if not os.getenv("PUB_OTEL_TRACING", "").lower() == "true":
+            return None
+
+        if TracingWrapper.__instance is None:
+            log.info("Creating TracingWrapper instance")
+            cls.__instance = super().__new__(cls)
+            otlp_exporter = OTLPSpanExporter(
+                endpoint=f"{os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT')}/v1/traces",
+            )
+            cls.provider = TracerProvider(
+                resource=Resource.create({SERVICE_NAME: os.getenv("OTEL_SERVICE_NAME")})
+            )
+            cls.processor = BatchSpanProcessor(otlp_exporter)
+            cls.provider.add_span_processor(cls.processor)
+            trace.set_tracer_provider(cls.provider)
+            set_global_textmap(propagator)
+            cls.tracer = trace.get_tracer(__name__)
+        return cls.__instance
+
+
+tracing_wrapper = TracingWrapper()
+
+
+def instrument_func(span_name=None, args_to_attr=False):
+    """Instrument tracing for a function.
+
+    Args:
+        span_name: str
+            Span name.
+        task_info: dict
+            Pub task information, which contains trace context.
+        args_to_attr: boolean
+            Add function parameters into span attributes
+
+    Returns:
+        The decorated function or class
+    """
+    tracer = trace.get_tracer(__name__)
+
+    def _instrument_func(func):
+        @functools.wraps(func)
+        def wrap(*args, **kwargs):
+            if not os.getenv("PUB_OTEL_TRACING", "").lower() == "true":
+                return func(*args, **kwargs)
+
+            attributes = {
+                "function_name": func.__qualname__,
+            }
+            if args_to_attr:
+                attributes["args"] = ", ".join(map(str, args))
+                attributes["kwargs"] = ", ".join("{}={}".format(k, v) for k, v in kwargs.items())
+
+            with tracer.start_as_current_span(
+                name=span_name or func.__qualname__,
+                attributes=attributes,
+            ) as span:
+                try:
+                    result = func(*args, **kwargs)
+                except Exception as exc:
+                    span.set_status(Status(StatusCode.ERROR))
+                    span.record_exception(exc)
+                    raise
+                finally:
+                    # Add baggage data into span attributes
+                    span.set_attributes(baggage.get_all())
+                return result
+
+        return wrap
+
+    return _instrument_func

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,6 @@ pubtools>=0.3.0
 iiblib
 pubtools-iib
 kerberos
-
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,30 @@
+import os
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from pubtools._quay.utils.tracing import instrument_func, TracingWrapper
+
+from unittest.mock import Mock
+import pytest
+
+
+def test_instrument_func():
+    os.environ["PUB_OTEL_TRACING"] = "true"
+
+    mock_export = Mock()
+    OTLPSpanExporter.export = mock_export
+
+    @instrument_func(args_to_attr=True)
+    def func_normal():
+        return 1
+
+    @instrument_func()
+    def func_with_exception():
+        raise Exception()
+
+    assert TracingWrapper()
+    assert func_normal() == 1
+    with pytest.raises(Exception):
+        func_with_exception()
+
+    TracingWrapper.processor.force_flush()
+    mock_export.assert_called()


### PR DESCRIPTION
Add instrumentation tracing for push steps, UMB message sending and receiving, skopeo command fuction, and push images with theadpool.

Propagating trace context to quay.io and registry-proxy is not implemented when use skopeo command, e.g: skopeo copy images since don't know how to instrument skopeo yet.